### PR TITLE
Remove commented lines in .gitignore

### DIFF
--- a/{{cookiecutter.project_name}}/.gitignore
+++ b/{{cookiecutter.project_name}}/.gitignore
@@ -6,7 +6,6 @@
 
 # The section below contains SSB specific ignores, not included in the Python-
 # and R-ignores from GitHub.
-
 *.csv
 *.db
 *.feather
@@ -103,28 +102,7 @@ target/
 profile_default/
 ipython_config.py
 
-# pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
-
 # pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#pdm.lock
 #   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
 #   in version control.
 #   https://pdm.fming.dev/#use-with-ide
@@ -173,14 +151,6 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
-
-
 # The section below is from the GitHub .gitignore template for R:
 # https://raw.githubusercontent.com/github/gitignore/main/R.gitignore
 
@@ -224,10 +194,6 @@ vignettes/*.pdf
 
 # R Environment Variables
 .Renviron
-
-# pkgdown site
-# SSB: The directory below is commented out because default when generating documentation with Sphinx
-#docs/
 
 # translation temp files
 po/*~


### PR DESCRIPTION
These could cause false positives when comparing against users' local copies of the files when running `ssb-project build`.