### PR TITLE
adding specific readme: to  pyproject.toml

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "{{cookiecutter.description}}"
 authors = ["{{cookiecutter.full_name}} <{{cookiecutter.email}}>"]
 license = "MIT"
+readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.11"


### PR DESCRIPTION
https://github.com/pypa/gh-action-pypi-publish/issues/162

After encountering this bug, it was solved by being specific on the path to readme-file in pyproject.toml. I dont see the harm in including this in the template to avoid this sort of bug on future projects.

In pyproject.toml:
`readme = "README.md"`