### PR TITLE
Tighten constraint for Python

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.10,<4"
+python = ">=3.10,<3.12"
 dapla-toolbelt = ">=1.3.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Sadly, SciPy locks the Python version and sets constraints very tightly (See https://github.com/scipy/scipy/issues/17957). Pandas depends on SciPy, and as such you will need to change the `pyproject.toml` file immediately when using Pandas in a project created by `ssb-project-cli.` The lesser evil is probably to match the Python-version in accordance with SciPy.