### PR TITLE
Update pyproject.toml

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -9,10 +9,10 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
 dapla-toolbelt = ">=1.3.2"
+ipykernel = ">=6.15.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.1.3"
-ipykernel = ">=6.15.3"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
moving ipykernel as non-dev dependency

See this Yammer post on bug report:
https://engage.cloud.microsoft/main/org/ssb.no/threads/eyJfdHlwZSI6IlRocmVhZCIsImlkIjoiMjc5ODIzMTMyMTA2NzUyMCJ9?trk_copy_link=V2

Boils down to:
- Stat-template only depended on ipykernel as a dev-dependency
- ssb-project-cli installs non-dev-dependencies
- ssb-project-cli calls ipykernel directly from the venv (which has not been installed by the previous step)