### PR TITLE
Added support for jupytext and automatic save as .py files

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -17,3 +17,9 @@ pytest = ">=7.1.3"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.jupytext]
+formats = "ipynb,auto:percent"
+notebook_metadata_filter = "jupytext.text_representation,-jupytext.text_representation.jupytext_version,-widgets,-varInspector"
+cell_metadata_filter = "-papermill,tags"
+


### PR DESCRIPTION
Added support for automatic saving of .py files from Notebook, according to ADR0020. ".gitignore" is currently not updated with ignore of ".ipynb" files, but at some point this must also be done. At the moment, it might cause confusion.