### PR TITLE
Add config for local packages

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -5,7 +5,11 @@ description = "{{cookiecutter.description}}"
 authors = ["{{cookiecutter.full_name}} <{{cookiecutter.email}}>"]
 license = "MIT"
 readme = "README.md"
-package-mode = false
+# To include functions in Jupyter Notebooks from other parts of the directory tree,
+# without using ProjectRoot from ssb-fagfunksjoner.
+packages = [
+    { include = "functions", from = "src" },
+]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"


### PR DESCRIPTION
- According to [Hvordan importere egendefinerte funksjoner i Jupyter Notebooks?](https://statistics-norway.atlassian.net/wiki/spaces/BEST/pages/3966075065/Hvordan+importere+egendefinerte+funksjoner+i+Jupyter+Notebooks)
- Removed package-mode = false since package mode is needed for local packages