### PR TITLE
Gjort pyproject.toml PEP 631 kompatibel

### DIFF
--- a/{{cookiecutter.project_name}}/poetry.lock
+++ b/{{cookiecutter.project_name}}/poetry.lock
@@ -1140,12 +1140,12 @@ files = [
 google-auth = ">=2.14.1,<3.0.0"
 googleapis-common-protos = ">=1.56.2,<2.0.0"
 grpcio = [
-    {version = ">=1.49.1,<2.0dev", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
     {version = ">=1.33.2,<2.0dev", optional = true, markers = "python_version < \"3.11\" and extra == \"grpc\""},
+    {version = ">=1.49.1,<2.0dev", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
 ]
 grpcio-status = [
-    {version = ">=1.49.1,<2.0.dev0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
     {version = ">=1.33.2,<2.0.dev0", optional = true, markers = "python_version < \"3.11\" and extra == \"grpc\""},
+    {version = ">=1.49.1,<2.0.dev0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
 ]
 proto-plus = ">=1.22.3,<2.0.0"
 protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<7.0.0"
@@ -1245,8 +1245,8 @@ grpcio-status = ">=1.33.2"
 opentelemetry-api = {version = ">=1.27.0", markers = "python_version >= \"3.8\""}
 opentelemetry-sdk = {version = ">=1.27.0", markers = "python_version >= \"3.8\""}
 proto-plus = [
-    {version = ">=1.22.2,<2.0.0", markers = "python_version >= \"3.11\""},
     {version = ">=1.22.0,<2.0.0", markers = "python_version < \"3.11\""},
+    {version = ">=1.22.2,<2.0.0", markers = "python_version >= \"3.11\""},
 ]
 protobuf = ">=3.20.2,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<7.0.0"
 
@@ -2620,9 +2620,9 @@ files = [
 [package.dependencies]
 lxml = {version = ">=4.9.2", optional = true, markers = "extra == \"xml\""}
 numpy = [
+    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
     {version = ">=1.23.2", markers = "python_version == \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
-    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
 ]
 odfpy = {version = ">=1.4.1", optional = true, markers = "extra == \"excel\""}
 openpyxl = {version = ">=3.1.0", optional = true, markers = "extra == \"excel\""}
@@ -4606,4 +4606,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "a7cd7b1351ea3d638596fe0ee42073172f42a101d4cd5c0a4729a33ab8b9a5c5"
+content-hash = "61dadb9b2e2918d826cfae841e80dfe50cb8e5856b0ab091d99c79bd9e6dc73a"

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -12,16 +12,6 @@ dependencies = [
     "ipykernel (>=6.15.3)",
 ]
 
-[dependency-groups]
-dev = [
-    "pytest (>=7.1.3)",
-    "pytest-cov (>=5.0.0)",
-    "black[jupyter] (>=24.4.2)",
-    "isort (>=5.12.0)",
-    "pre-commit (>=3.3.1)",
-    "pre-commit-hooks (>=4.4.0)",
-]
-
 [tool.poetry]
 # To include functions in Jupyter Notebooks from other parts of the directory tree,
 # without using ProjectRoot from ssb-fagfunksjoner.

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -1,22 +1,35 @@
-[tool.poetry]
+[project]
 name = "{{cookiecutter.project_name}}"
-version = "0.1.0"
 description = "{{cookiecutter.description}}"
-authors = ["{{cookiecutter.full_name}} <{{cookiecutter.email}}>"]
 license = "MIT"
+version = "0.1.0"
 readme = "README.md"
+authors = [{name = "{{cookiecutter.full_name}}", email = "{{cookiecutter.email}}"}]
+requires-python = ">=3.10,<3.13"
+dependencies = [
+    "dapla-toolbelt (>=1.3.2)", 
+    "dynaconf (>=3.2.6)", 
+    "ipykernel (>=6.15.3)",
+]
+
+[dependency-groups]
+dev = [
+    "pytest (>=7.1.3)",
+    "pytest-cov (>=5.0.0)",
+    "black[jupyter] (>=24.4.2)",
+    "isort (>=5.12.0)",
+    "pre-commit (>=3.3.1)",
+    "pre-commit-hooks (>=4.4.0)",
+]
+
+[tool.poetry]
 # To include functions in Jupyter Notebooks from other parts of the directory tree,
 # without using ProjectRoot from ssb-fagfunksjoner.
 packages = [
     { include = "config" },
     { include = "functions", from = "src" },
 ]
-
-[tool.poetry.dependencies]
-python = ">=3.10,<3.13"
-dapla-toolbelt = ">=1.3.2"
-dynaconf = ">=3.2.6"
-ipykernel = ">=6.15.3"
+requires-poetry = ">=2.0.0,<3.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.1.3"


### PR DESCRIPTION
Migrert attributter fra «tool.poetry»-seksjon til «project»-seksjon med «[poetry-plugin-migrate](https://github.com/zyf722/poetry-plugin-migrate)», og gjort avhengighetsspesifikasjonen PEP 631 kompatibel.
Dette gjør det enklere å senere «teste ut uv», for de som ønsker det.
